### PR TITLE
fix(carousel): correct import path in carousel documentation

### DIFF
--- a/contents/components/data-display/carousel/index.ja.mdx
+++ b/contents/components/data-display/carousel/index.ja.mdx
@@ -9,6 +9,12 @@ tab: 使い方
 
 ## インポート
 
+<PackageManagers packageNameOrCommand="@yamada-ui/carousel" />
+
+:::note status=warning
+`@yamada-ui/carousel`は、`@yamada-ui/react`に含まれていないため、別途インストールする必要があります。
+:::
+
 ```ts
 import {
   Carousel,
@@ -16,7 +22,7 @@ import {
   CarouselControlNext,
   CarouselControlPrev,
   CarouselIndicators,
-} from "@yamada-ui/react"
+} from "@yamada-ui/carousel"
 ```
 
 - `Carousel`: 子要素(`CarouselSlide`)を制御するラッパーコンポーネントです。

--- a/contents/components/data-display/carousel/index.mdx
+++ b/contents/components/data-display/carousel/index.mdx
@@ -9,6 +9,12 @@ tab: Usage
 
 ## Import
 
+<PackageManagers packageNameOrCommand="@yamada-ui/carousel" />
+
+:::note status=warning
+`@yamada-ui/carousel` is not included in `@yamada-ui/react`, so it needs to be installed separately.
+:::
+
 ```ts
 import {
   Carousel,
@@ -16,7 +22,7 @@ import {
   CarouselControlNext,
   CarouselControlPrev,
   CarouselIndicators,
-} from "@yamada-ui/react"
+} from "@yamada-ui/carousel"
 ```
 
 - `Carousel`: A wrapper component that controls the child elements (`CarouselSlide`).


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #150

## Description

This PR corrects the import path for Carousel components in the documentation.

## Current behavior (updates)

The current documentation incorrectly suggests importing Carousel components from the `@yamada-ui/react` package.

## New behavior

This PR updates the documentation to correctly suggest importing Carousel components from the `@yamada-ui/carousel` package.

## Is this a breaking change (Yes/No):

No
