### PR TITLE
fix: overflowY for table-of-contents

### DIFF
--- a/components/navigation/table-of-contents.tsx
+++ b/components/navigation/table-of-contents.tsx
@@ -99,7 +99,7 @@ export const TableOfContents = memo(
           pt="lg"
           pb="16"
           pl="md"
-          overflowY="scroll"
+          overflowY="auto"
           overscrollBehavior="contain"
         >
           <HStack gap="sm">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #172 

## Description

In the `table-of-contents.tsx` file, the `table-of-contents` component is currently set to use `overflowY: scroll`. This causes a scrollbar to be permanently visible, even when the content does not overflow the container.

## Current behavior (updates)

`table-of-contents` have `overflow-y: "scroll"` causing the scrollbar to permanently show.

## New behavior

Changes to `overflow-y: "auto"`

## Is this a breaking change (Yes/No):

No