### PR TITLE
fix(cli): can select bun in PackageManagers

### DIFF
--- a/contents/styled-system/cli.ja.mdx
+++ b/contents/styled-system/cli.ja.mdx
@@ -17,7 +17,7 @@ CLIは、カスタマイズしたテーマを読み取り、`node_modules/@yamad
     pnpm: "pnpm add --dev @yamada-ui/cli",
     npm: "npm install --save-dev @yamada-ui/cli",
     yarn: "yarn add --dev @yamada-ui/cli",
-    bun: "bun install @yamada-ui/cli",
+    bun: "bun add --dev @yamada-ui/cli",
   }}
 />
 

--- a/contents/styled-system/cli.ja.mdx
+++ b/contents/styled-system/cli.ja.mdx
@@ -17,6 +17,7 @@ CLIは、カスタマイズしたテーマを読み取り、`node_modules/@yamad
     pnpm: "pnpm add --dev @yamada-ui/cli",
     npm: "npm install --save-dev @yamada-ui/cli",
     yarn: "yarn add --dev @yamada-ui/cli",
+    bun: "bun install @yamada-ui/cli",
   }}
 />
 
@@ -51,6 +52,7 @@ CLIは、カスタマイズしたテーマを読み取り、`node_modules/@yamad
     pnpm: "pnpm theme",
     npm: "npm run theme",
     yarn: "yarn theme",
+    bun: "bun run theme",
   }}
 />
 
@@ -61,5 +63,6 @@ CLIは、カスタマイズしたテーマを読み取り、`node_modules/@yamad
     pnpm: "pnpm theme:watch",
     npm: "npm run theme:watch",
     yarn: "yarn theme:watch",
+    bun: "bun run theme:watch",
   }}
 />

--- a/contents/styled-system/cli.mdx
+++ b/contents/styled-system/cli.mdx
@@ -17,7 +17,7 @@ Run either of the following commands in the terminal.
     pnpm: "pnpm add --dev @yamada-ui/cli",
     npm: "npm install --save-dev @yamada-ui/cli",
     yarn: "yarn add --dev @yamada-ui/cli",
-    bun: "bun install @yamada-ui/cli",
+    bun: "bun add --dev @yamada-ui/cli",
   }}
 />
 

--- a/contents/styled-system/cli.mdx
+++ b/contents/styled-system/cli.mdx
@@ -17,6 +17,7 @@ Run either of the following commands in the terminal.
     pnpm: "pnpm add --dev @yamada-ui/cli",
     npm: "npm install --save-dev @yamada-ui/cli",
     yarn: "yarn add --dev @yamada-ui/cli",
+    bun: "bun install @yamada-ui/cli",
   }}
 />
 
@@ -51,6 +52,7 @@ To generate the type of theme, execute any of the following scripts.
     pnpm: "pnpm theme",
     npm: "npm run theme",
     yarn: "yarn theme",
+    bun: "bun run theme",
   }}
 />
 
@@ -61,5 +63,6 @@ If you want to continuously generate types while customizing the theme, execute 
     pnpm: "pnpm theme:watch",
     npm: "npm run theme:watch",
     yarn: "yarn theme:watch",
+    bun: "bun run theme:watch",
   }}
 />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #176

## Description

> In cli page, can select bun in PackageManagers

## Current behavior (updates)

> In cli page, To select bun in PackageManagers has error. 

## New behavior

> In cli page, can select bun in PackageManagers

## Is this a breaking change (Yes/No):

No

## Additional Information

`bun install` add package to `devDependencies` by default
https://bun.sh/docs/cli/install
