### PR TITLE
fix(cli): update options for installing with pnpm

### DIFF
--- a/contents/styled-system/cli.ja.mdx
+++ b/contents/styled-system/cli.ja.mdx
@@ -14,7 +14,7 @@ CLIは、カスタマイズしたテーマを読み取り、`node_modules/@yamad
 
 <PackageManagers
   packageNameOrCommand={{
-    pnpm: "pnpm add --dev @yamada-ui/cli",
+    pnpm: "pnpm add --save-dev @yamada-ui/cli",
     npm: "npm install --save-dev @yamada-ui/cli",
     yarn: "yarn add --dev @yamada-ui/cli",
   }}

--- a/contents/styled-system/cli.mdx
+++ b/contents/styled-system/cli.mdx
@@ -14,7 +14,7 @@ Run either of the following commands in the terminal.
 
 <PackageManagers
   packageNameOrCommand={{
-    pnpm: "pnpm add --dev @yamada-ui/cli",
+    pnpm: "pnpm add --save-dev @yamada-ui/cli",
     npm: "npm install --save-dev @yamada-ui/cli",
     yarn: "yarn add --dev @yamada-ui/cli",
   }}


### PR DESCRIPTION
Closes #178 

## Description

This pull request updates document about the options for installing with pnpm.

## Current behavior (updates)

Currently, the documentation suggests using the --dev option when installing with pnpm.

## New behavior

This pull request proposes updating the documentation to suggest using the --save-dev option instead of --dev for installing with pnpm.

## Is this a breaking change (Yes/No):

No

## Additional Information

I referred to [this document](https://pnpm.io/ja/cli/add#--save-dev--d)